### PR TITLE
added support for ThinkPad Keyboard Plugin Core 2.0.0.15

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -54,7 +54,7 @@ namespace ConsoleApp1
                 MethodInfo getKeyboardBackLightLevelInfo = GetRuntimeMethodsExt(myType, "GetKeyboardBackLightLevel", new Type[] { });
                 MethodInfo setKeyboardBackLightStatusInfo = GetRuntimeMethodsExt(myType, "SetKeyboardBackLightStatus", new Type[] { });
 
-                object[] arguments = new object[] { Int32.Parse(args[1]) };
+                object[] arguments = new object[] { Int32.Parse(args[1]), null };
                 UInt32 output = (UInt32)setKeyboardBackLightStatusInfo.Invoke(obj, arguments);
 
                 //UInt32 output = (UInt32)getKeyboardBackLightLevelInfo.Invoke(obj, arguments);


### PR DESCRIPTION
The change made here is a hotfix to address [issue 5](https://github.com/ligius-/lenovo-backlight-control/issues/5).
In addition to _SetKeyboardBackLightStatus_ being passed a backlight level integer, it is passed a null value for the _HidKbdData_ parameter.